### PR TITLE
add flyway, job stderr, kafka for job results

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -67,6 +67,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-database-postgresql</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/api/src/main/java/dev/heisen/api/dto/JobResultResponse.java
+++ b/api/src/main/java/dev/heisen/api/dto/JobResultResponse.java
@@ -2,6 +2,7 @@ package dev.heisen.api.dto;
 
 public record JobResultResponse(
         String stdout,
-        int exitCode
+        String stderr,
+        Integer exitCode
 ) {
 }

--- a/api/src/main/java/dev/heisen/api/event/JobCompileEvent.java
+++ b/api/src/main/java/dev/heisen/api/event/JobCompileEvent.java
@@ -3,14 +3,13 @@ package dev.heisen.api.event;
 import dev.heisen.api.model.Language;
 import lombok.Builder;
 
-import java.time.Instant;
 import java.util.UUID;
 
 @Builder
-public record JobEvent(
+public record JobCompileEvent(
         UUID jobId,
         Language lang,
-        String codeRef,
-        Instant createdAt
+        String code,
+        String stdin
 ) {
 }

--- a/api/src/main/java/dev/heisen/api/event/JobResultEvent.java
+++ b/api/src/main/java/dev/heisen/api/event/JobResultEvent.java
@@ -1,0 +1,16 @@
+package dev.heisen.api.event;
+
+import dev.heisen.api.model.JobStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record JobResultEvent(
+       UUID id,
+       JobStatus status,
+       String stdout,
+       String stderr,
+       Integer exitCode,
+       Instant finishedAt
+) {
+}

--- a/api/src/main/java/dev/heisen/api/model/Job.java
+++ b/api/src/main/java/dev/heisen/api/model/Job.java
@@ -36,6 +36,9 @@ public class Job {
     @Lob
     private String stdout;
 
+    @Lob
+    private String stderr;
+
     @Column(name = "exit_code")
     private Integer exitCode;
 

--- a/api/src/main/java/dev/heisen/api/model/JobStatus.java
+++ b/api/src/main/java/dev/heisen/api/model/JobStatus.java
@@ -3,5 +3,6 @@ package dev.heisen.api.model;
 public enum JobStatus {
     PENDING,
     PROCESSING,
-    COMPLETED
+    COMPLETED,
+    FAILED
 }

--- a/api/src/main/java/dev/heisen/api/service/JobService.java
+++ b/api/src/main/java/dev/heisen/api/service/JobService.java
@@ -1,17 +1,20 @@
 package dev.heisen.api.service;
 
+import dev.heisen.api.event.JobResultEvent;
 import dev.heisen.api.exception.JobNotFoundException;
 import dev.heisen.api.dto.JobRequest;
 import dev.heisen.api.dto.JobResponse;
 import dev.heisen.api.dto.JobResultResponse;
 import dev.heisen.api.dto.JobStatusResponse;
-import dev.heisen.api.event.JobEvent;
+import dev.heisen.api.event.JobCompileEvent;
 import dev.heisen.api.model.Job;
 import dev.heisen.api.model.JobStatus;
 import dev.heisen.api.repository.JobRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -23,7 +26,9 @@ import java.util.UUID;
 @Transactional
 public class JobService {
 
-    private static final String KAFKA_TOPIC = "job-create";
+    @Value("${spring.kafka.producer.topic}")
+    private String producerTopic;
+
     private final KafkaService kafkaService;
     private final JobRepository jobRepository;
 
@@ -43,13 +48,13 @@ public class JobService {
                 .build();
         jobRepository.save(job);
 
-        JobEvent event = JobEvent.builder()
+        JobCompileEvent event = JobCompileEvent.builder()
                 .jobId(jobId)
                 .lang(jobRequest.lang())
-                .codeRef("db://jobs/" + jobId)
-                .createdAt(now)
+                .code(jobRequest.code())
+                .stdin(jobRequest.stdin())
                 .build();
-        kafkaService.sendMessage(KAFKA_TOPIC, event);
+        kafkaService.sendMessage(producerTopic, event);
 
         return new JobResponse(jobId);
     }
@@ -57,9 +62,7 @@ public class JobService {
     public JobStatusResponse getStatus(UUID id) {
         log.info("Getting job status with id {}", id);
 
-        Job job = jobRepository.findById(id).orElseThrow(
-                () -> new JobNotFoundException("Job with id " + id + " not found")
-        );
+        Job job = findJobById(id);
 
         return new JobStatusResponse(job.getStatus());
     }
@@ -67,13 +70,41 @@ public class JobService {
     public JobResultResponse getResult(UUID id) {
         log.info("Getting job result with id {}", id);
 
-        Job job = jobRepository.findById(id).orElseThrow(
-                () -> new JobNotFoundException("Job with id " + id + " not found")
-        );
+        Job job = findJobById(id);
 
         return new JobResultResponse(
                 job.getStdout(),
+                job.getStderr(),
                 job.getExitCode()
+        );
+    }
+
+    @KafkaListener(topics = "${spring.kafka.consumer.topic}", groupId = "${spring.kafka.consumer.group-id}")
+    public void consumeJobResult(JobResultEvent resultEvent) {
+        log.info("Received Job Result Event {}", resultEvent);
+
+        try {
+            Job job = findJobById(resultEvent.id());
+
+            job.setStatus(resultEvent.status());
+            job.setStdout(resultEvent.stdout());
+            job.setStderr(resultEvent.stderr());
+            job.setExitCode(resultEvent.exitCode());
+            job.setFinishedAt(resultEvent.finishedAt());
+
+            jobRepository.save(job);
+            log.info("Successfully updated job with id: {}", resultEvent.id());
+
+        } catch (JobNotFoundException e) {
+            log.error("Received result for non-existent job id: {}. Ignoring.", resultEvent.id(), e);
+        } catch (Exception e) {
+            log.error("Error processing job result event: {}", resultEvent, e);
+        }
+    }
+
+    private Job findJobById(UUID id) {
+        return jobRepository.findById(id).orElseThrow(
+                () -> new JobNotFoundException("Job with id " + id + " not found")
         );
     }
 }

--- a/api/src/main/java/dev/heisen/api/service/KafkaService.java
+++ b/api/src/main/java/dev/heisen/api/service/KafkaService.java
@@ -1,6 +1,6 @@
 package dev.heisen.api.service;
 
-import dev.heisen.api.event.JobEvent;
+import dev.heisen.api.event.JobCompileEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -11,9 +11,9 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class KafkaService {
 
-    private final KafkaTemplate<String, JobEvent> kafkaTemplate;
+    private final KafkaTemplate<String, JobCompileEvent> kafkaTemplate;
 
-    public void sendMessage(String topic, JobEvent event) {
+    public void sendMessage(String topic, JobCompileEvent event) {
         log.info("Sending job request to topic {}", topic);
         kafkaTemplate.send(topic, event);
     }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -13,9 +13,12 @@ spring:
     password: ${POSTGRES_PASSWORD:postgres}
     driver-class-name: org.postgresql.Driver
 
+  flyway:
+    enabled: true
+
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true
 
   jackson:
@@ -23,16 +26,13 @@ spring:
       accept-case-insensitive-enums: true
 
   kafka:
-    bootstrap-servers:
-      - localhost:9092
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-
-logging:
-  level:
-    org:
-      hibernate:
-        orm:
-          jdbc:
-            bind: TRACE
+      topic: compile-jobs
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      topic: compile-results
+      group-id: api-service-group

--- a/api/src/main/resources/db/migration/V1__init.sql
+++ b/api/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,13 @@
+CREATE TABLE jobs
+(
+    id          UUID                        NOT NULL,
+    lang        VARCHAR(255)                NOT NULL,
+    status      VARCHAR(255)                NOT NULL,
+    code        OID                         NOT NULL,
+    stdin       OID,
+    stdout      OID,
+    exit_code   INTEGER,
+    created_at  TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    finished_at TIMESTAMP WITHOUT TIME ZONE,
+    CONSTRAINT pk_jobs PRIMARY KEY (id)
+);

--- a/api/src/main/resources/db/migration/V2__add_stderr_col_to_jobs_table.sql
+++ b/api/src/main/resources/db/migration/V2__add_stderr_col_to_jobs_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE jobs
+    ADD stderr OID;


### PR DESCRIPTION
**Job result handling**

* Added `stderr` field to the `Job` model
* Updated job status enum to include a `FAILED` state
* Implemented a new `JobResultEvent` class and corresponding Kafka listener in `JobService` to consume job results and update job records

**Database schema management**

* Integrated Flyway for database migrations and disabled Hibernate's automatic schema updates

**Configuration and environment improvements**

* Updated application configuration to support environment variables for Kafka and database settings, improving deployment flexibility.

**Testing**

* Improved and extended unit tests to cover new event handling logic and job result